### PR TITLE
fix: lets add a proxy secret manager

### DIFF
--- a/pkg/cmd/verify/verify.go
+++ b/pkg/cmd/verify/verify.go
@@ -105,7 +105,7 @@ func (o *VerifyOptions) Run() error {
 		return nil
 	}
 
-	err = o.pushToGit(err, dir)
+	err = o.pushToGit(dir)
 	if err != nil {
 		return err
 	}
@@ -114,7 +114,7 @@ func (o *VerifyOptions) Run() error {
 	return nil
 }
 
-func (o *VerifyOptions) pushToGit(err error, dir string) error {
+func (o *VerifyOptions) pushToGit(dir string) error {
 	gitURL := o.GitCloneURL
 	gitInfo, err := gits.ParseGitURL(gitURL)
 	if err != nil {

--- a/pkg/secretmgr/constants.go
+++ b/pkg/secretmgr/constants.go
@@ -12,6 +12,7 @@ const (
 
 	// LocalSecret the name of the Kubernetes Secret used to load/store the
 	// secrets
+	/* #nosec */
 	LocalSecret = "jx-boot-secrets"
 
 	// LocalSecretKey the key in the local Secret to store the YAML secrets

--- a/pkg/secretmgr/constants.go
+++ b/pkg/secretmgr/constants.go
@@ -12,7 +12,7 @@ const (
 
 	// LocalSecret the name of the Kubernetes Secret used to load/store the
 	// secrets
-	LocalSecret = "helmboot-secrets"
+	LocalSecret = "jx-boot-secrets"
 
 	// LocalSecretKey the key in the local Secret to store the YAML secrets
 	LocalSecretKey = "secrets.yaml"

--- a/pkg/secretmgr/factory/factory.go
+++ b/pkg/secretmgr/factory/factory.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jenkins-x-labs/helmboot/pkg/secretmgr/fake"
 	"github.com/jenkins-x-labs/helmboot/pkg/secretmgr/gsm"
 	"github.com/jenkins-x-labs/helmboot/pkg/secretmgr/local"
+	"github.com/jenkins-x-labs/helmboot/pkg/secretmgr/proxy"
 	"github.com/jenkins-x/jx/pkg/config"
 	"github.com/jenkins-x/jx/pkg/jxfactory"
 )
@@ -18,7 +19,16 @@ func NewSecretManager(kind string, f jxfactory.Factory, requirements *config.Req
 	}
 	switch kind {
 	case secretmgr.KindGoogleSecretManager:
-		return gsm.NewGoogleSecretManager(requirements)
+		// lets populate a local secret after importing/editing the google secret
+		l, err := local.NewLocalSecretManager(f)
+		if err != nil {
+			return nil, err
+		}
+		g, err := gsm.NewGoogleSecretManager(requirements)
+		if err != nil {
+			return nil, err
+		}
+		return proxy.NewProxySecretManager(g, l), nil
 	case secretmgr.KindLocal:
 		return local.NewLocalSecretManager(f)
 	case secretmgr.KindFake:

--- a/pkg/secretmgr/proxy/proxy.go
+++ b/pkg/secretmgr/proxy/proxy.go
@@ -1,0 +1,49 @@
+package proxy
+
+import (
+	"github.com/jenkins-x-labs/helmboot/pkg/secretmgr"
+)
+
+// ProxySecretManager stores the updated secret in the secret storage
+type ProxySecretManager struct {
+	First  secretmgr.SecretManager
+	Second secretmgr.SecretManager
+}
+
+// NewProxySecretManager uses a Kubernetes Secret to manage secrets
+func NewProxySecretManager(first, second secretmgr.SecretManager) secretmgr.SecretManager {
+	return &ProxySecretManager{First: first, Second: second}
+}
+
+// UpsertSecrets upserts the secrets
+func (f *ProxySecretManager) UpsertSecrets(callback secretmgr.SecretCallback, defaultYaml string) error {
+
+	updatedYaml := ""
+
+	proxyCallback := func(secretYaml string) (string, error) {
+		y, err := callback(secretYaml)
+		if err != nil {
+			return y, err
+		}
+		updatedYaml = y
+		return y, nil
+	}
+
+	err := f.First.UpsertSecrets(proxyCallback, defaultYaml)
+	if err != nil {
+		return err
+	}
+
+	populateCallback := func(secretYaml string) (string, error) {
+		return updatedYaml, nil
+	}
+	return f.Second.UpsertSecrets(populateCallback, defaultYaml)
+}
+
+func (f *ProxySecretManager) Kind() string {
+	return f.First.Kind()
+}
+
+func (f *ProxySecretManager) String() string {
+	return f.First.String()
+}


### PR DESCRIPTION
so we can always backup the GSM secrets to a k8s Secret for canonical
mounting of the boot secrets in a k8s Job or tekton pipeline